### PR TITLE
Fix render.yaml: Change cronJobs to crons and update schedules to JST

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -18,9 +18,9 @@ databases:
     user: parts_sync
 
 # Cron Jobs for eBay sync
-cronJobs:
+crons:
   - name: ebay-sync-morning
-    schedule: "0 6 * * *"  # 毎日朝6時 (UTC)
+    schedule: "0 21 * * *"  # 毎日朝6時 JST (21:00 UTC = 6:00 JST)
     buildCommand: "./bin/render-build.sh"
     startCommand: "bundle exec rake ebay:sync_all"
     env: ruby
@@ -33,7 +33,7 @@ cronJobs:
         sync: false
   
   - name: ebay-sync-afternoon
-    schedule: "0 14 * * *"  # 毎日昼14時 (UTC)
+    schedule: "0 5 * * *"  # 毎日昼14時 JST (05:00 UTC = 14:00 JST)
     buildCommand: "./bin/render-build.sh"
     startCommand: "bundle exec rake ebay:sync_all"
     env: ruby
@@ -46,7 +46,7 @@ cronJobs:
         sync: false
   
   - name: ebay-sync-evening
-    schedule: "0 20 * * *"  # 毎日夜20時 (UTC)
+    schedule: "0 11 * * *"  # 毎日夜20時 JST (11:00 UTC = 20:00 JST)
     buildCommand: "./bin/render-build.sh"
     startCommand: "bundle exec rake ebay:sync_all"
     env: ruby


### PR DESCRIPTION
- Fixed syntax error: cronJobs -> crons
- Updated cron schedules for JST timezone:
  - Morning: 21:00 UTC (6:00 JST)
  - Afternoon: 05:00 UTC (14:00 JST)
  - Evening: 11:00 UTC (20:00 JST)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 定期実行ジョブの設定キーを `cronJobs` から `crons` に変更しました。
  * eBay同期ジョブのスケジュールをJST基準の時刻に合わせて調整しました。
  * コメントをJSTと新しいUTC時刻に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->