### PR TITLE
render.yamlにプランを追加: parts-sync-appをスタートプランに、ebay-sync-morning、ebay-sy…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,7 @@ services:
   - type: web
     name: parts-sync-app
     runtime: ruby
+    plan: starter
     buildCommand: './bin/render-build.sh'
     startCommand: 'bundle exec puma -C config/puma.rb'
     envVars:
@@ -17,6 +18,7 @@ services:
   - type: cron
     name: ebay-sync-morning
     runtime: ruby
+    plan: standard
     schedule: '0 21 * * *' # 21:00 UTC = 06:00 JST
     startCommand: 'bundle exec rake ebay:sync_all'
     envVars:
@@ -31,6 +33,7 @@ services:
   - type: cron
     name: ebay-sync-afternoon
     runtime: ruby
+    plan: standard
     schedule: '0 5 * * *' # 05:00 UTC = 14:00 JST
     startCommand: 'bundle exec rake ebay:sync_all'
     envVars:
@@ -45,6 +48,7 @@ services:
   - type: cron
     name: ebay-sync-evening
     runtime: ruby
+    plan: standard
     schedule: '0 11 * * *' # 11:00 UTC = 20:00 JST
     startCommand: 'bundle exec rake ebay:sync_all'
     envVars:


### PR DESCRIPTION
…nc-afternoon、ebay-sync-eveningをスタンダードプランに設定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * サービス構成に「plan」属性を追加し、各サービスのプラン設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->