### PR TITLE
Add debug script for cron job troubleshooting

### DIFF
--- a/bin/debug-cron.sh
+++ b/bin/debug-cron.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -x  # デバッグモード
+
+echo "=== DEBUG: Starting cron job ==="
+echo "Date: $(date)"
+echo "PWD: $(pwd)"
+echo "Ruby: $(which ruby)"
+echo "Bundle: $(which bundle)"
+echo "DATABASE_URL exists: $(if [ -n "$DATABASE_URL" ]; then echo "YES"; else echo "NO"; fi)"
+
+echo "=== DEBUG: Checking bundle ==="
+bundle check || bundle install
+
+echo "=== DEBUG: Running rake with timeout ==="
+timeout 300 bundle exec rake ebay:sync_all --trace
+
+exit_code=$?
+echo "=== DEBUG: Exit code: $exit_code ==="
+
+if [ $exit_code -eq 124 ]; then
+  echo "=== DEBUG: Command timed out after 5 minutes ==="
+fi
+
+exit $exit_code

--- a/render.yaml
+++ b/render.yaml
@@ -21,7 +21,7 @@ services:
     plan: standard
     schedule: '0 21 * * *' # 21:00 UTC = 06:00 JST
     buildCommand: './bin/cron-build.sh'
-    startCommand: '/bin/bash -l -c "bundle exec rake ebay:sync_all"'
+    startCommand: './bin/debug-cron.sh'
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -37,7 +37,7 @@ services:
     plan: standard
     schedule: '0 5 * * *' # 05:00 UTC = 14:00 JST
     buildCommand: './bin/cron-build.sh'
-    startCommand: '/bin/bash -l -c "bundle exec rake ebay:sync_all"'
+    startCommand: './bin/debug-cron.sh'
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -53,7 +53,7 @@ services:
     plan: standard
     schedule: '0 11 * * *' # 11:00 UTC = 20:00 JST
     buildCommand: './bin/cron-build.sh'
-    startCommand: '/bin/bash -l -c "bundle exec rake ebay:sync_all"'
+    startCommand: './bin/debug-cron.sh'
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
- Create debug-cron.sh to diagnose hanging cron jobs
- Add verbose logging and timeout handling
- Update render.yaml to use debug script
- This helps identify database connection issues

The cron job was hanging for 20+ minutes without output. This debug script will help identify if it's a database connection timeout or other initialization issue.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * cronジョブのデバッグ用スクリプトが追加され、実行時の詳細な診断情報やタイムアウト時のメッセージ表示が可能になりました。

* **運用改善**
  * cronサービスの実行コマンドが新しいデバッグ用スクリプト経由に変更され、トラブルシューティングが容易になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->