### PR TITLE
render.yamlのcronジョブ設定を更新し、`startCommand`をデバッグスクリプトから`bundle exec rake…

### DIFF
--- a/bin/debug-cron.sh
+++ b/bin/debug-cron.sh
@@ -11,14 +11,11 @@ echo "DATABASE_URL exists: $(if [ -n "$DATABASE_URL" ]; then echo "YES"; else ec
 echo "=== DEBUG: Checking bundle ==="
 bundle check || bundle install
 
-echo "=== DEBUG: Running rake with timeout ==="
-timeout 300 bundle exec rake ebay:sync_all --trace
+echo "=== DEBUG: Running rake without timeout ==="
+bundle exec rake ebay:sync_all --trace
 
 exit_code=$?
 echo "=== DEBUG: Exit code: $exit_code ==="
 
-if [ $exit_code -eq 124 ]; then
-  echo "=== DEBUG: Command timed out after 5 minutes ==="
-fi
 
 exit $exit_code

--- a/render.yaml
+++ b/render.yaml
@@ -21,7 +21,7 @@ services:
     plan: standard
     schedule: '0 21 * * *' # 21:00 UTC = 06:00 JST
     buildCommand: './bin/cron-build.sh'
-    startCommand: './bin/debug-cron.sh'
+    startCommand: 'bundle exec rake ebay:sync_all'
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -37,7 +37,7 @@ services:
     plan: standard
     schedule: '0 5 * * *' # 05:00 UTC = 14:00 JST
     buildCommand: './bin/cron-build.sh'
-    startCommand: './bin/debug-cron.sh'
+    startCommand: 'bundle exec rake ebay:sync_all'
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -53,7 +53,7 @@ services:
     plan: standard
     schedule: '0 11 * * *' # 11:00 UTC = 20:00 JST
     buildCommand: './bin/cron-build.sh'
-    startCommand: './bin/debug-cron.sh'
+    startCommand: 'bundle exec rake ebay:sync_all'
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
… ebay:sync_all`に変更。`debug-cron.sh`ではタイムアウトを削除し、デバッグメッセージを追加しました。これにより、cronジョブの実行がより効率的になります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * cronサービスで実行されるコマンドが直接Rakeタスク実行に変更され、タイムアウト制限がなくなりました。  
  * タイムアウト時のデバッグメッセージが削除され、よりシンプルな動作となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->