### PR TITLE
Fix database connection for cron jobs

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,7 @@ services:
       - key: DATABASE_URL
         fromDatabase:
           name: parts-sync-app-db2
-          property: connectionString
+          property: databaseUrl
       - key: RAILS_MASTER_KEY
         sync: false
 
@@ -26,7 +26,7 @@ services:
       - key: DATABASE_URL
         fromDatabase:
           name: parts-sync-app-db2
-          property: connectionString
+          property: databaseUrl
       - key: RAILS_MASTER_KEY
         sync: false
 
@@ -42,7 +42,7 @@ services:
       - key: DATABASE_URL
         fromDatabase:
           name: parts-sync-app-db2
-          property: connectionString
+          property: databaseUrl
       - key: RAILS_MASTER_KEY
         sync: false
 
@@ -58,6 +58,6 @@ services:
       - key: DATABASE_URL
         fromDatabase:
           name: parts-sync-app-db2
-          property: connectionString
+          property: databaseUrl
       - key: RAILS_MASTER_KEY
         sync: false


### PR DESCRIPTION
- Change database property from connectionString to databaseUrl
- This uses external database URL instead of internal hostname
- Resolves "could not translate host name" error in cron jobs
- Internal URLs (dpg-xxx-a) are not accessible from cron services

🤖 Generated with [Claude Code](https://claude.ai/code)