### PR TITLE
ログの改善

### DIFF
--- a/app/services/ebay/ebay_finance_client.rb
+++ b/app/services/ebay/ebay_finance_client.rb
@@ -13,9 +13,12 @@ module Ebay
       Rails.logger.debug "fetch_transactions called with filters: #{filters}"
       all_transactions = []
       offset = 0
-      limit = 1000
+      limit = 200 # バッチサイズを1000から200に削減
+      max_transactions = 10000 # 最大取得件数制限
 
       loop do
+        Rails.logger.info "📥 eBay Finance API - offset: #{offset}, limit: #{limit}"
+
         response = client.get do |req|
           req.url TRANSACTION_ENDPOINT
           Rails.logger.debug "Request URL: #{TRANSACTION_ENDPOINT}"
@@ -38,6 +41,14 @@ module Ebay
         all_transactions.concat(transactions)
         offset += limit
 
+        Rails.logger.info "📊 取得済み件数: #{all_transactions.size} / #{result['total']}"
+
+        # 最大件数制限チェック
+        if all_transactions.size >= max_transactions
+          Rails.logger.warn "⚠️  最大取得件数(#{max_transactions})に達しました。処理を停止します。"
+          break
+        end
+
         break if all_transactions.size >= result["total"].to_i
       end
 
@@ -46,9 +57,19 @@ module Ebay
 
     rescue Faraday::Error => e
       Rails.logger.error "eBay Finance API Error: #{e.response&.body}"
+      Rails.logger.error "Error class: #{e.class.name}"
+      Rails.logger.error "Error message: #{e.message}"
       raise FinanceError, "取引情報取得エラー: #{e.message}"
+    rescue Net::ReadTimeout => e
+      Rails.logger.error "eBay Finance API Timeout: #{e.message}"
+      raise FinanceError, "API応答タイムアウト: #{e.message}"
+    rescue Net::OpenTimeout => e
+      Rails.logger.error "eBay Finance API Connection Timeout: #{e.message}"
+      raise FinanceError, "API接続タイムアウト: #{e.message}"
     rescue StandardError => e
       Rails.logger.error "Unexpected Error in fetch_transactions: #{e.message}"
+      Rails.logger.error "Error class: #{e.class.name}"
+      Rails.logger.error "Backtrace: #{e.backtrace.first(5).join('\n')}"
       raise FinanceError, "予期せぬエラーが発生しました: #{e.message}"
     end
 
@@ -59,6 +80,8 @@ module Ebay
         faraday.request :json
         faraday.response :raise_error
         faraday.adapter Faraday.default_adapter
+        faraday.options.timeout = 300 # 5分のタイムアウト
+        faraday.options.open_timeout = 60 # 1分の接続タイムアウト
       end
     end
 

--- a/app/services/ebay/transactions/sale_transaction_processor.rb
+++ b/app/services/ebay/transactions/sale_transaction_processor.rb
@@ -19,6 +19,8 @@ module Ebay
 
         return fee_processed unless transaction["orderLineItems"].is_a?(Array)
 
+        Rails.logger.info "🔄 処理開始 - orderLineItems: #{transaction['orderLineItems'].size}件"
+
         transaction["orderLineItems"].each_with_index do |item, idx|
           Rails.logger.debug "Processing orderLineItem #{idx}: #{item.keys.inspect}"
 
@@ -27,13 +29,19 @@ module Ebay
             next
           end
 
+          Rails.logger.info "💰 手数料処理 - item #{idx}: #{item['marketplaceFees'].size}件"
+
           item["marketplaceFees"].each_with_index do |fee, fee_idx|
+            Rails.logger.debug "Processing fee #{fee_idx}/#{item['marketplaceFees'].size} of item #{idx}"
             if process_single_fee(fee, idx, fee_idx)
               fee_processed = true
             end
           end
+
+          Rails.logger.info "✅ item #{idx} 完了"
         end
 
+        Rails.logger.info "🎯 marketplace_fees処理完了 - 処理済み: #{fee_processed}"
         fee_processed
       end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * eBay取引データの取得時、バッチサイズが1000件から200件に変更され、最大取得件数が10,000件に制限されました。
  * 取引取得処理やマーケットプレイス手数料処理において、進捗や詳細状況を示すログ出力が強化されました。
  * 通信タイムアウト時のエラーメッセージが分かりやすくなり、例外発生時のログ情報がより詳細になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->